### PR TITLE
Feature creinkin allauth email verify template

### DIFF
--- a/public_discourse_sandbox/templates/account/email/email_confirmation_message.html
+++ b/public_discourse_sandbox/templates/account/email/email_confirmation_message.html
@@ -1,0 +1,31 @@
+{% extends "email/base_email.html" %}
+{% load account %}
+{% load i18n %}
+
+{% block title %}Verify Your Email - Public Discourse Sandbox{% endblock %}
+
+{% block content %}{% autoescape off %}{% user_display user as user_display %}
+<h2>Verify Your Email Address</h2>
+
+<p>Hello {{ user_display }},</p>
+
+<p>Thank you for signing up for <b>Public Discourse Sandbox</b>! To complete your registration and verify your email address, please click the button below:</p>
+
+<div class="card">
+    <div style="text-align: center;">
+        <p style="color: var(--secondary-text); margin-bottom: 16px;">Click to verify your email address</p>
+        <a href="{{ activate_url }}" class="button">Verify Email Address</a>
+    </div>
+    
+    <hr style="border: none; border-top: 1px solid var(--border-color); margin: 20px 0;">
+    
+    <p style="margin-bottom: 8px; color: var(--secondary-text);">If the button doesn't work, copy and paste this link:</p>
+    <p style="word-break: break-all; color: var(--navy); margin-bottom: 0; font-family: monospace; background: white; padding: 12px; border-radius: 6px; border: 1px solid var(--border-color);"> {{ activate_url }}</p>
+</div>
+
+{% comment %} <p style="color: var(--secondary-text);"><strong>Note:</strong> This verification link will expire in 24 hours.</p> {% endcomment %}
+
+<p style="margin-bottom: 24px;">If you didn't create an account with Public Discourse Sandbox, you can safely ignore this email.</p>
+
+<p style="margin-bottom: 0; color: var(--secondary-text); margin-right: 50px;">From,<br><b><i>The Public Discourse Sandbox Team</i></b></p>
+{% endautoescape %}{% endblock content %} 

--- a/public_discourse_sandbox/templates/account/email/email_confirmation_signup_message.html
+++ b/public_discourse_sandbox/templates/account/email/email_confirmation_signup_message.html
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_message.html" %}

--- a/public_discourse_sandbox/templates/email/base_email.html
+++ b/public_discourse_sandbox/templates/email/base_email.html
@@ -28,37 +28,18 @@
             background-color: var(--light-bg);
         }
         .email-layout {
-            display: flex;
-            max-width: 1200px;
+            max-width: 640px;
             margin: 0 auto;
             min-height: 100vh;
             background-color: white;
-        }
-        .sidebar-left {
-            width: 280px;
-            background-color: white;
-            padding: 40px 20px;
-            flex-shrink: 0;
-        }
-        .main-content {
-            flex-grow: 1;
             padding: 40px;
-            background-color: white;
-            border-left: 1px solid var(--border-color);
-            border-right: 1px solid var(--border-color);
-            max-width: 640px;
-        }
-        .sidebar-right {
-            width: 280px;
-            background-color: white;
-            padding: 40px 20px;
-            flex-shrink: 0;
         }
         .logo-section {
             display: flex;
             align-items: center;
             gap: 12px;
             text-decoration: none;
+            margin-bottom: 40px;
         }
         .logo-icon {
             width: 48px;
@@ -154,30 +135,24 @@
 </head>
 <body>
     <div class="email-layout">
-        <div class="sidebar-left">
-            <div class="logo-section">
-                <div class="logo-icon">
-                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"/>
-                    </svg>
-                </div>
-                <div class="brand-text">
-                    <span class="brand-name">Public Discourse</span>
-                    <span class="sandbox-label">Sandbox</span>
-                </div>
+        <div class="logo-section">
+            <div class="logo-icon">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"/>
+                </svg>
+            </div>
+            <div class="brand-text">
+                <span class="brand-name">Public Discourse</span>
+                <span class="sandbox-label">Sandbox</span>
             </div>
         </div>
         
-        <div class="main-content">
-            {% block content %}{% endblock %}
-            
-            <div class="footer">
-                <p style="margin-bottom: 8px;">© Public Discourse Sandbox. All rights reserved.</p>
-                <p style="margin-bottom: 0;">This is an automated message, please do not reply to this email.</p>
-            </div>
+        {% block content %}{% endblock %}
+        
+        <div class="footer">
+            <p style="margin-bottom: 8px;">© Public Discourse Sandbox. All rights reserved.</p>
+            <p style="margin-bottom: 0;">This is an automated message, please do not reply to this email.</p>
         </div>
-
-        <div class="sidebar-right"></div>
     </div>
 </body>
 </html> 


### PR DESCRIPTION
This PR demonstrates a first override of one of the django-allauth transactional emails. 

The documentation on this topic is here: https://docs.allauth.org/en/latest/common/email.html

The way to override any email is to:

- look at the messages here: https://github.com/pennersr/django-allauth/tree/65.4.1/allauth/templates/account/email 
- find the email content that we want to override
- create a new .html file inside of the templates/account/email directory of the same name
- utilize the context available in the .txt version to bring into the html version.

This PR overrides both of the ways allauth sends email verification. One version is directly after signup. The other would be if they need to re-trigger an email verification after the sign up flow.

Here is a screenshot of how this email renders on a tablet-sized client:

<img width="730" alt="image" src="https://github.com/user-attachments/assets/2f3c9d7f-dab5-4bd9-9df6-6c255630436c" />


