### PR TITLE
Media Directory Permissions

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -85,6 +85,7 @@ RUN chmod +x /start-flower
 
 # copy application code to WORKDIR
 COPY --chown=django:django . ${APP_HOME}
+RUN mkdir -p ${APP_HOME}/public_discourse_sandbox/media
 
 # make django owner of the WORKDIR directory as well.
 RUN chown -R django:django ${APP_HOME}


### PR DESCRIPTION
As of some Docker version ago (unsure when) the named volumes do not have write permissions for the non-root users inside the container to write to them. This is seen as inability to upload any media file. 

Found the solution here: https://stackoverflow.com/a/64034092