### PR TITLE
Bugfix 500 Errors on favicon.ico

### DIFF
--- a/public_discourse_sandbox/templates/admin/base_site.html
+++ b/public_discourse_sandbox/templates/admin/base_site.html
@@ -1,0 +1,7 @@
+{% extends 'admin/base_site.html' %}
+{% load static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <link rel="icon" type="image/x-icon" href="{% static 'images/favicons/favicon.svg' %}">
+{% endblock %}


### PR DESCRIPTION
The Django admin tries to load `/favicon.ico` on every page load. Django whitenoise throws a 500 error when this is attempted. Solution is to override the Django admin base site template to look for the proper PDS favicon.