### PR TITLE
better hashtag parsing

### DIFF
--- a/public_discourse_sandbox/pds_app/dt_service.py
+++ b/public_discourse_sandbox/pds_app/dt_service.py
@@ -396,6 +396,9 @@ class DTService:
                 depth=post.depth + 1
             )
 
+            # Save the comment again to perform hashtag parsing after the post ID exists
+            comment.save()
+
             # Create a notification for the parent post author
             Notification.objects.create(
                 user_profile=post.user_profile,
@@ -599,7 +602,7 @@ Output only the text of the post, with no additional commentary or explanation.
             )
             
             # Extract and clean the content
-            content = response.choices[0].message.content.strip()
+            content = response.choices[0].message.content.strip().strip('"').strip()
             
             # If content exceeds maximum allowed length, trim it
             if len(content) > 280:
@@ -648,12 +651,16 @@ Output only the text of the post, with no additional commentary or explanation.
                 return None
                 
             # Create a new post from the digital twin
+            # Important: Use create() + save() to make sure the post ID is set before the hashtag parsing runs
             new_post = Post.objects.create(
                 user_profile=twin.user_profile,
                 experiment=twin.user_profile.experiment,
                 content=post_content,
                 depth=0  # Top-level post
             )
+
+            # Save the post again to perform hashtag parsing after the post ID exists
+            new_post.save()
             
             # Update the last_post timestamp for the twin
             twin.last_post = timezone.now()

--- a/public_discourse_sandbox/pds_app/models.py
+++ b/public_discourse_sandbox/pds_app/models.py
@@ -202,20 +202,28 @@ class Post(BaseModel):
     def parse_hashtags(self):
         """
         Returns a list of hashtags for this post.
+        Uses regex to find Twitter-style hashtags that contain only alphanumeric chars and underscores.
         """
+        import re
+        
         if self.content:
-            # Process hashtags
-            for word in self.content.split():
-                if word.startswith('#'):
-                    hashtag = word[1:]  # Remove the # symbol
-                    print("Hashtag: ", hashtag)
-                    try:
-                        hashtag, created = Hashtag.objects.get_or_create(
-                            tag=hashtag.lower(),
-                            post=self
-                        )
-                    except Exception as e:
-                        print(f"Error processing hashtag {hashtag}: {e}")
+            print("Parsing hashtags for post: ", self.content)
+            # Find all hashtags using regex
+            # Matches # followed by word chars (letters, numbers, underscore)
+            # The (?<!\S) ensures the # has whitespace or start-of-string before it
+            hashtag_pattern = r'(?<!\S)#([a-zA-Z0-9_]+)'
+            matches = re.finditer(hashtag_pattern, self.content)
+            
+            for match in matches:
+                hashtag = match.group(1)  # group(1) gets just the tag without the #
+                print("Hashtag: ", hashtag)
+                try:
+                    hashtag, created = Hashtag.objects.get_or_create(
+                        tag=hashtag.lower(),
+                        post=self
+                    )
+                except Exception as e:
+                    print(f"Error processing hashtag {hashtag}: {e}")
 
     def save(self, *args, **kwargs):
         # Check for profanity in content


### PR DESCRIPTION
This PR has a few changes to address #64 

The hashtag parsing by using `Post.objects.create()` was silently failing because the post did not have an ID yet to make a foreign key link to.

The dt service was changed to do a second save() method after post creation in order to re-trigger the hashtag parsing flow.

Also updated the regex parsing to better adhere to alphanumeric characters plus underscores. This will help avoid hashtags that end in punctuation.