### PR TITLE
broad htmx event listener to make hashtags clickable

### DIFF
--- a/public_discourse_sandbox/static/js/shared.js
+++ b/public_discourse_sandbox/static/js/shared.js
@@ -164,3 +164,12 @@ document.addEventListener('DOMContentLoaded', function() {
         makeHashtagsClickable(modal);
     });
 });
+
+document.body.addEventListener('htmx:afterSwap', function(evt) {
+    // Get the container that was just updated
+    const container = evt.detail.target.parentElement;
+    console.log("htmx:afterSwap", container);
+    if (container) {
+        makeHashtagsClickable(container);
+    }
+});


### PR DESCRIPTION
This works but is technical debt. This PR is the quick fix for #72 using the latter method of iterating over the parent container when an htmx swap happens. This should be more targeted and may cause issues later down the line. But for now the function should be scoped to only things within the swapped parent container and with the proper post class.